### PR TITLE
Add Method type, use google/cmp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3
+	github.com/google/go-cmp v0.5.9
 	golang.org/x/tools v0.14.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
 github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Joffref/genz/internal/parser"
+	"github.com/google/go-cmp/cmp"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -131,7 +132,7 @@ func TestParseSuccess(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(gotStruct, tc.expectedStruct) {
-				t.Fatalf("expected %s, got %s", tc.expectedStruct, gotStruct)
+				t.Fatalf("output struct doesn't match expected:\n%s", cmp.Diff(gotStruct, tc.expectedStruct))
 			}
 		})
 	}

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -5,11 +5,22 @@ type (
 		Type Type
 
 		Attributes []Attribute
+		Methods    []Method
 	}
 
 	Attribute struct {
 		Name string
 		Type Type
+
+		Comments []string
+	}
+
+	Method struct {
+		Name              string
+		Params            []Type
+		Returns           []Type
+		IsPointerReceiver bool
+		IsExported        bool
 
 		Comments []string
 	}


### PR DESCRIPTION
Proposal to add parser.Method type 

Why adding go-cmp in this PR?
- Adding another slice of struct (Methods) in parser.Struct raised an error while trying to convert struct to string (probably because the struct became too big to be strigified or too many sub structs).
- Before : comparing expected and got struct was hard (also not showing difference between nil and empty slice/map)
- After : 1 stable dependency provides a much better comparison for testing and debugging
eg.
```
=== NAME  TestParseSuccess/attribute_with_doc
    parser_test.go:134: output struct doesn't match expected:
          parser.Struct{
          	Type: "A",
          	Attributes: []parser.Attribute{
          		{
          			Name: "foo",
          			Type: "string",
          			Comments: []string{
        + 				"comment 1",
          				"comment 2",
          			},
          		},
          	},
          	Methods: nil,
          }

```
- Can be easily replaced with a custom implementation if we want to remove the dep in the future.
