### PR TITLE
Allow importing templates from an http or https remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,17 +103,17 @@ Explore built-in `examples`, clone repo, and run `go generate ./...` in the root
 ### CLI
 ```bash
 Usage of genz:
-        genz [flags] -type T -template foo.tmpl [directory]
-        genz [flags] -type T -template foo.tmpl files... # Must be a single package
+	genz [flags] -type T -template foo.tmpl [directory]
+	genz [flags] -type T -template foo.tmpl files... # Must be a single package
 Flags:
   -output string
-        output file name; default srcdir/<type>.gen.go
+    	output file name; default srcdir/<type>.gen.go
   -tags string
-        comma-separated list of build tags to apply
+    	comma-separated list of build tags to apply
   -template string
-        go-template file name
+    	go-template local or remote file
   -type string
-        comma-separated list of type names; must be set
+    	comma-separated list of type names; must be set
 ```
 
 ## Contributing

--- a/cmd/genz/genz.go
+++ b/cmd/genz/genz.go
@@ -3,9 +3,9 @@ package genz
 import (
 	"flag"
 	"fmt"
-    "io/ioutil"
+	"io/ioutil"
 	"log"
-    "net/http"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,25 +68,25 @@ func (c generateCommand) Run() error {
 	if len(*buildTags) > 0 {
 		tags = strings.Split(*buildTags, ",")
 	}
-    
-    var template []byte;
-    if strings.HasPrefix(*templateFile, "http://") || strings.HasPrefix(*templateFile, "https://") {
-        response, err := http.Get(*templateFile)
-    	if err != nil {
-    		return fmt.Errorf("failed to make a request to %s: %v", *templateFile, err)
-    	}
-        body, err := ioutil.ReadAll(response.Body)
-    	if err != nil {
-    		return fmt.Errorf("could not read body of remote template %s: %v", *templateFile, err)
-    	}
-        template = body
-    } else {
-        file, err := os.ReadFile(*templateFile)
-    	if err != nil {
-    		return fmt.Errorf("failed to read template file %s: %v", *templateFile, err)
-    	}
-        template = file;
-    }
+
+	var template []byte
+	if strings.HasPrefix(*templateFile, "http://") || strings.HasPrefix(*templateFile, "https://") {
+		response, err := http.Get(*templateFile)
+		if err != nil {
+			return fmt.Errorf("failed to make a request to %s: %v", *templateFile, err)
+		}
+		body, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			return fmt.Errorf("could not read body of remote template %s: %v", *templateFile, err)
+		}
+		template = body
+	} else {
+		file, err := os.ReadFile(*templateFile)
+		if err != nil {
+			return fmt.Errorf("failed to read template file %s: %v", *templateFile, err)
+		}
+		template = file
+	}
 
 	// We accept either one directory or a list of files. Which do we have?
 	args := generateCmd.Args()
@@ -125,7 +125,7 @@ func (c generateCommand) Run() error {
 		outputName = filepath.Join(dir, strings.ToLower(baseName))
 	}
 
-    if err := os.WriteFile(outputName, src, 0644); err != nil {
+	if err := os.WriteFile(outputName, src, 0644); err != nil {
 		return fmt.Errorf("writing output: %s", err)
 	}
 

--- a/cmd/genz/genz.go
+++ b/cmd/genz/genz.go
@@ -3,7 +3,7 @@ package genz
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+    "io"
 	"log"
 	"net/http"
     "net/url"
@@ -76,7 +76,7 @@ func (c generateCommand) Run() error {
 		if err != nil {
 			return fmt.Errorf("failed to make a request to %s: %v", *templateFile, err)
 		}
-		body, err := ioutil.ReadAll(response.Body)
+		body, err := io.ReadAll(response.Body)
 		if err != nil {
 			return fmt.Errorf("could not read body of remote template %s: %v", *templateFile, err)
 		}

--- a/cmd/genz/genz.go
+++ b/cmd/genz/genz.go
@@ -3,10 +3,10 @@ package genz
 import (
 	"flag"
 	"fmt"
-    "io"
+	"io"
 	"log"
 	"net/http"
-    "net/url"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,11 +27,11 @@ Flags:`
 )
 
 var (
-	generateCmd  = flag.NewFlagSet("", flag.ExitOnError)
-	typeNames    = generateCmd.String("type", "", "comma-separated list of type names; must be set")
+	generateCmd      = flag.NewFlagSet("", flag.ExitOnError)
+	typeNames        = generateCmd.String("type", "", "comma-separated list of type names; must be set")
 	templateLocation = generateCmd.String("template", "", "go-template local or remote file")
-	output       = generateCmd.String("output", "", "output file name; default srcdir/<type>.gen.go")
-	buildTags    = generateCmd.String("tags", "", "comma-separated list of build tags to apply")
+	output           = generateCmd.String("output", "", "output file name; default srcdir/<type>.gen.go")
+	buildTags        = generateCmd.String("tags", "", "comma-separated list of build tags to apply")
 )
 
 func init() {
@@ -71,7 +71,7 @@ func (c generateCommand) Run() error {
 	}
 
 	var template []byte
-    if url, _ := url.ParseRequestURI(*templateLocation); url != nil {
+	if url, _ := url.ParseRequestURI(*templateLocation); url != nil {
 		response, err := http.Get(*templateLocation)
 		if err != nil {
 			return fmt.Errorf("failed to make a request to %s: %v", *templateLocation, err)

--- a/cmd/genz/genz.go
+++ b/cmd/genz/genz.go
@@ -29,7 +29,7 @@ Flags:`
 var (
 	generateCmd  = flag.NewFlagSet("", flag.ExitOnError)
 	typeNames    = generateCmd.String("type", "", "comma-separated list of type names; must be set")
-	templateFile = generateCmd.String("template", "", "go-template file name")
+	templateLocation = generateCmd.String("template", "", "go-template local or remote file")
 	output       = generateCmd.String("output", "", "output file name; default srcdir/<type>.gen.go")
 	buildTags    = generateCmd.String("tags", "", "comma-separated list of build tags to apply")
 )
@@ -50,7 +50,7 @@ func (c generateCommand) ValidateArgs() error {
 		generateCmd.Usage()
 		return fmt.Errorf("missing 'type' argument")
 	}
-	if len(*templateFile) == 0 {
+	if len(*templateLocation) == 0 {
 		generateCmd.Usage()
 		return fmt.Errorf("missing 'template' argument")
 	}
@@ -71,20 +71,20 @@ func (c generateCommand) Run() error {
 	}
 
 	var template []byte
-    if url, _ := url.ParseRequestURI(*templateFile); url != nil {
-		response, err := http.Get(*templateFile)
+    if url, _ := url.ParseRequestURI(*templateLocation); url != nil {
+		response, err := http.Get(*templateLocation)
 		if err != nil {
-			return fmt.Errorf("failed to make a request to %s: %v", *templateFile, err)
+			return fmt.Errorf("failed to make a request to %s: %v", *templateLocation, err)
 		}
 		body, err := io.ReadAll(response.Body)
 		if err != nil {
-			return fmt.Errorf("could not read body of remote template %s: %v", *templateFile, err)
+			return fmt.Errorf("could not read body of remote template %s: %v", *templateLocation, err)
 		}
 		template = body
 	} else {
-		file, err := os.ReadFile(*templateFile)
+		file, err := os.ReadFile(*templateLocation)
 		if err != nil {
-			return fmt.Errorf("failed to read template file %s: %v", *templateFile, err)
+			return fmt.Errorf("failed to read template file %s: %v", *templateLocation, err)
 		}
 		template = file
 	}

--- a/cmd/genz/genz.go
+++ b/cmd/genz/genz.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+    "net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,7 +71,7 @@ func (c generateCommand) Run() error {
 	}
 
 	var template []byte
-	if strings.HasPrefix(*templateFile, "http://") || strings.HasPrefix(*templateFile, "https://") {
+    if url, _ := url.ParseRequestURI(*templateFile); url != nil {
 		response, err := http.Get(*templateFile)
 		if err != nil {
 			return fmt.Errorf("failed to make a request to %s: %v", *templateFile, err)


### PR DESCRIPTION
This will fulfill and satisfy the requirements in this issue https://github.com/Joffref/genz/issues/18. It does not download the file because I could not see any need to do so, it just makes it go off of memory.